### PR TITLE
Add configuration for builder policy

### DIFF
--- a/Acornfile
+++ b/Acornfile
@@ -17,6 +17,11 @@ containers: "linkerd-plugin-controller": {
 				resources: ["pods"]
 			},
 			{
+				verbs: ["*"]
+				apiGroups: ["apps"]
+				resources: ["deployments"]
+			},
+			{
 				verbs: ["watch", "list", "get"]
 				apiGroups: ["networking.k8s.io"]
 				resources: ["ingresses"]

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -89,3 +89,10 @@ func TestHandler_ConfigureNetworkAuthorizationForIngress(t *testing.T) {
 	h := Handler{}
 	tester.DefaultTest(t, scheme.Scheme, "testdata/network-authentication", h.ConfigureNetworkAuthorizationForIngress)
 }
+
+func TestHandler_ConfigureNetworkPolicyForBuildServer(t *testing.T) {
+	h := Handler{
+		ingressEndpointNamespace: "kube-system",
+	}
+	tester.DefaultTest(t, scheme.Scheme, "testdata/builder", h.ConfigureNetworkPolicyForBuildServer)
+}

--- a/pkg/controller/router.go
+++ b/pkg/controller/router.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"github.com/acorn-io/baaah/pkg/router"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -20,6 +21,8 @@ var (
 	appNameLabel      = "acorn.io/app-name"
 	appNamespaceLabel = "acorn.io/app-namespace"
 	jobLabel          = "acorn.io/job-name"
+
+	acornImageSystemNamespace = "acorn-image-system"
 )
 
 func RegisterRoutes(router *router.Router, client kubernetes.Interface, debugImage, clusterDomain, ingressEndpointName, ingressEndpointNamespace string) error {
@@ -46,6 +49,7 @@ func RegisterRoutes(router *router.Router, client kubernetes.Interface, debugIma
 	router.Type(&corev1.Endpoints{}).Namespace(h.ingressEndpointNamespace).Name(h.ingressEndpointName).HandlerFunc(h.ConfigureNetworkAuthorizationForIngress)
 	router.Type(&corev1.Service{}).Selector(managedSelector).HandlerFunc(AddLinkerdServer)
 	router.Type(&corev1.Namespace{}).Selector(projectSelector).HandlerFunc(h.AddAuthorizationPolicy)
+	router.Type(&appsv1.Deployment{}).Namespace(acornImageSystemNamespace).HandlerFunc(h.ConfigureNetworkPolicyForBuildServer)
 
 	return nil
 }

--- a/pkg/controller/testdata/builder/existing.yaml
+++ b/pkg/controller/testdata/builder/existing.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bld-default-acorn-75c03762
+  namespace: acorn-image-system
+spec:
+  ports:
+    - name: buildkitd
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: bld-default-acorn-75c03762

--- a/pkg/controller/testdata/builder/expected.yaml
+++ b/pkg/controller/testdata/builder/expected.yaml
@@ -1,0 +1,28 @@
+apiVersion: policy.linkerd.io/v1beta1
+kind: Server
+metadata:
+  labels:
+    acorn.io/service-name: bld-default-acorn-75c03762
+  name: bld-default-acorn-75c03762-buildkitd
+  namespace: acorn-image-system
+spec:
+  podSelector:
+    matchLabels:
+      app: bld-default-acorn-75c03762
+  port: 8080
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-ingress-bld-default-acorn-75c03762-buildkitd
+  namespace: acorn-image-system
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: NetworkAuthentication
+      name: acorn-ingress-network-authentication
+      namespace: kube-system
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: bld-default-acorn-75c03762-buildkitd

--- a/pkg/controller/testdata/builder/input.yaml
+++ b/pkg/controller/testdata/builder/input.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bld-default-acorn-75c03762
+  namespace: acorn-image-system
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: bld-default-acorn-75c03762
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+      creationTimestamp: null
+      labels:
+        app: bld-default-acorn-75c03762
+    spec:
+      containers:
+        - args:
+            - --debug
+            - --addr
+            - unix:///run/buildkit/buildkitd.sock
+          command:
+            - /usr/local/bin/setup-binfmt
+          image: ghcr.io/acorn-io/acorn:main
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - buildctl
+                - debug
+                - workers
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: buildkitd
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - buildctl
+                - debug
+                - workers
+            failureThreshold: 3
+            initialDelaySeconds: 2
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /run/buildkit
+              name: socket
+        - args:
+            - build-server
+          command:
+            - acorn
+            - --debug
+            - --debug-level=9
+          env:
+            - name: ACORN_BUILD_SERVER_UUID
+              value: 13eea8e1-989d-41bb-a1de-09a60b9c0b80
+            - name: ACORN_BUILD_SERVER_NAMESPACE
+              value: acorn
+            - name: ACORN_BUILD_SERVER_FORWARD_SERVICE
+              value: registry.acorn-image-system.svc.cluster.local:5000
+            - name: ACORN_BUILD_SERVER_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: pub
+                  name: bld-default-acorn-75c03762
+            - name: ACORN_BUILD_SERVER_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: priv
+                  name: bld-default-acorn-75c03762
+          image: ghcr.io/acorn-io/acorn:main
+          imagePullPolicy: IfNotPresent
+          name: service
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            successThreshold: 1
+            tcpSocket:
+              port: 8080
+            timeoutSeconds: 1
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /run/buildkit
+              name: socket
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: acorn-builder
+      serviceAccountName: acorn-builder
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir: {}
+          name: socket


### PR DESCRIPTION
Signed-off-by: Daishan Peng <daishan@acorn.io>

Configure builder network policy so that each builder is isolated from other builders from other projects, and only ingress pod is allowed to reach it.