### PR TITLE
Allow ingress access by default

### DIFF
--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -65,7 +65,8 @@ func TestHandler_AddLinkerdServer(t *testing.T) {
 
 func TestHandler_AddAuthorizationPolicy(t *testing.T) {
 	h := Handler{
-		clusterDomain: "cluster.local",
+		clusterDomain:            "cluster.local",
+		ingressEndpointNamespace: "kube-system",
 	}
 	tester.DefaultTest(t, scheme.Scheme, "testdata/authorization-policy", h.AddAuthorizationPolicy)
 }

--- a/pkg/controller/handlers.go
+++ b/pkg/controller/handlers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -218,19 +217,7 @@ func (h Handler) AddAuthorizationPolicy(req router.Request, resp router.Response
 
 		// Check if service is referenced by an ingress, and if so, create an authorization policy that
 		// allow traffic from ingress pod
-		var ingressList networkingv1.IngressList
-		if err := req.Client.List(req.Ctx, &ingressList, &client.ListOptions{
-			Namespace: server.Namespace,
-			LabelSelector: labels.SelectorFromSet(map[string]string{
-				serviceNameLabel: server.Labels[serviceNameLabel],
-			}),
-		}); err != nil {
-			return err
-		}
-
-		if len(ingressList.Items) == 0 {
-			continue
-		}
+		// Todo: For now we want to allow access from ingress by default. We can program some smart way to figure out whether service needs to be exposed by ingress
 
 		resp.Objects(&policyv1alpha1.AuthorizationPolicy{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/testdata/authorization-policy/expected.yaml
+++ b/pkg/controller/testdata/authorization-policy/expected.yaml
@@ -39,3 +39,35 @@ spec:
     group: policy.linkerd.io
     kind: Server
     name: bar-80
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-ingress-foo-80
+  namespace: foo1
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: NetworkAuthentication
+      name: acorn-ingress-network-authentication
+      namespace: kube-system
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: foo-80
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-ingress-bar-80
+  namespace: foo2
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: NetworkAuthentication
+      name: acorn-ingress-network-authentication
+      namespace: kube-system
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: bar-80


### PR DESCRIPTION
Signed-off-by: Daishan Peng <daishan@acorn.io>

Currently we are only programming authurization policy for services that is actually referenced by an ingress, which is hard to detect when service is referenced by an acorn router.

In the future we might need to be smart and figure out whether a service is referenced by an ingress and only program policy if it is exposed. For now we just open access to ingress pod by default.