### PR TITLE
Add policy for router deployment

### DIFF
--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -97,3 +97,11 @@ func TestHandler_ConfigureNetworkPolicyForBuildServer(t *testing.T) {
 	}
 	tester.DefaultTest(t, scheme.Scheme, "testdata/builder", h.ConfigureNetworkPolicyForBuildServer)
 }
+
+func TestHandler_AddAuthorizationPolicy_Deployment(t *testing.T) {
+	h := Handler{
+		clusterDomain:            "cluster.local",
+		ingressEndpointNamespace: "kube-system",
+	}
+	tester.DefaultTest(t, scheme.Scheme, "testdata/authorization-policy-with-deployment", h.AddAuthorizationPolicy)
+}

--- a/pkg/controller/testdata/authorization-policy-with-deployment/existing.yaml
+++ b/pkg/controller/testdata/authorization-policy-with-deployment/existing.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    acorn.io/app-name: green-sunset
+    acorn.io/app-namespace: acorn
+    acorn.io/managed: "true"
+  name: foo1
+spec:
+  finalizers:
+    - kubernetes
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    acorn.io/app-name: green-sunset
+    acorn.io/app-namespace: acorn
+    acorn.io/managed: "true"
+  name: foo2
+spec:
+  finalizers:
+    - kubernetes
+status:
+  phase: Active
+---
+apiVersion: policy.linkerd.io/v1beta1
+kind: Server
+metadata:
+  name: foo-80
+  namespace: foo1
+spec:
+  podSelector:
+    matchLabels:
+      acorn.io/app-name: bitter-smoke
+      acorn.io/app-namespace: acorn
+      acorn.io/managed: "true"
+  port: 80
+---
+apiVersion: policy.linkerd.io/v1beta1
+kind: Server
+metadata:
+  name: bar-80
+  namespace: foo2
+spec:
+  podSelector:
+    matchLabels:
+      acorn.io/app-name: bitter-smoke
+      acorn.io/app-namespace: acorn
+      acorn.io/managed: "true"
+  port: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bar-80
+  namespace: acorn-system
+  labels:
+    acorn.io/app-namespace: acorn
+spec:
+  template:
+    spec:
+      serviceAccountName: sa

--- a/pkg/controller/testdata/authorization-policy-with-deployment/expected.yaml
+++ b/pkg/controller/testdata/authorization-policy-with-deployment/expected.yaml
@@ -1,0 +1,74 @@
+apiVersion: policy.linkerd.io/v1alpha1
+kind: MeshTLSAuthentication
+metadata:
+  name: mesh-authn-profile-acorn
+  namespace: acorn
+spec:
+  identities:
+    - '*.foo1.serviceaccount.identity.linkerd.cluster.local'
+    - '*.foo2.serviceaccount.identity.linkerd.cluster.local'
+    - 'sa.acorn-system.serviceaccount.identity.linkerd.cluster.local'
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-acorn-foo-80
+  namespace: foo1
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: MeshTLSAuthentication
+      name: mesh-authn-profile-acorn
+      namespace: acorn
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: foo-80
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-acorn-bar-80
+  namespace: foo2
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: MeshTLSAuthentication
+      name: mesh-authn-profile-acorn
+      namespace: acorn
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: bar-80
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-ingress-foo-80
+  namespace: foo1
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: NetworkAuthentication
+      name: acorn-ingress-network-authentication
+      namespace: kube-system
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: foo-80
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-ingress-bar-80
+  namespace: foo2
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: NetworkAuthentication
+      name: acorn-ingress-network-authentication
+      namespace: kube-system
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: bar-80

--- a/pkg/controller/testdata/authorization-policy-with-deployment/input.yaml
+++ b/pkg/controller/testdata/authorization-policy-with-deployment/input.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    foo: bar
+  labels:
+    acorn.io/project: "true"
+  name: acorn
+spec:
+  finalizers:
+    - kubernetes
+status:
+  phase: Active


### PR DESCRIPTION
Signed-off-by: Daishan Peng <daishan@acorn.io>

For acorn routers, we create a special deployment in acorn-system to forward requests. These services need to be configured with proper policy to forward traffic to apps.