### PR TITLE
Add policy for router server defined in system namespace

### DIFF
--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -105,3 +105,11 @@ func TestHandler_AddAuthorizationPolicy_Deployment(t *testing.T) {
 	}
 	tester.DefaultTest(t, scheme.Scheme, "testdata/authorization-policy-with-deployment", h.AddAuthorizationPolicy)
 }
+
+func TestHandler_AddAuthorizationPolicy_Router(t *testing.T) {
+	h := Handler{
+		clusterDomain:            "cluster.local",
+		ingressEndpointNamespace: "kube-system",
+	}
+	tester.DefaultTest(t, scheme.Scheme, "testdata/authorization-policy-with-router-service", h.AddAuthorizationPolicy)
+}

--- a/pkg/controller/testdata/authorization-policy-with-router-service/existing.yaml
+++ b/pkg/controller/testdata/authorization-policy-with-router-service/existing.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    acorn.io/app-name: green-sunset
+    acorn.io/app-namespace: acorn
+    acorn.io/managed: "true"
+  name: foo1
+spec:
+  finalizers:
+    - kubernetes
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    acorn.io/app-name: green-sunset
+    acorn.io/app-namespace: acorn
+    acorn.io/managed: "true"
+  name: foo2
+spec:
+  finalizers:
+    - kubernetes
+status:
+  phase: Active
+---
+apiVersion: policy.linkerd.io/v1beta1
+kind: Server
+metadata:
+  name: foo-80
+  namespace: foo1
+spec:
+  podSelector:
+    matchLabels:
+      acorn.io/app-name: bitter-smoke
+      acorn.io/app-namespace: acorn
+      acorn.io/managed: "true"
+  port: 80
+---
+apiVersion: policy.linkerd.io/v1beta1
+kind: Server
+metadata:
+  name: bar-80
+  namespace: foo2
+spec:
+  podSelector:
+    matchLabels:
+      acorn.io/app-name: bitter-smoke
+      acorn.io/app-namespace: acorn
+      acorn.io/managed: "true"
+  port: 80
+---
+apiVersion: policy.linkerd.io/v1beta1
+kind: Server
+metadata:
+  name: router
+  namespace: acorn-system
+  labels:
+    acorn.io/app-name: bitter-smoke
+    acorn.io/app-namespace: acorn
+spec:
+  podSelector:
+    matchLabels:
+      acorn.io/app-name: bitter-smoke
+      acorn.io/app-namespace: acorn
+      acorn.io/managed: "true"
+  port: 80

--- a/pkg/controller/testdata/authorization-policy-with-router-service/expected.yaml
+++ b/pkg/controller/testdata/authorization-policy-with-router-service/expected.yaml
@@ -1,0 +1,106 @@
+apiVersion: policy.linkerd.io/v1alpha1
+kind: MeshTLSAuthentication
+metadata:
+  name: mesh-authn-profile-acorn
+  namespace: acorn
+spec:
+  identities:
+    - '*.foo1.serviceaccount.identity.linkerd.cluster.local'
+    - '*.foo2.serviceaccount.identity.linkerd.cluster.local'
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-acorn-foo-80
+  namespace: foo1
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: MeshTLSAuthentication
+      name: mesh-authn-profile-acorn
+      namespace: acorn
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: foo-80
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-acorn-bar-80
+  namespace: foo2
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: MeshTLSAuthentication
+      name: mesh-authn-profile-acorn
+      namespace: acorn
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: bar-80
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-ingress-foo-80
+  namespace: foo1
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: NetworkAuthentication
+      name: acorn-ingress-network-authentication
+      namespace: kube-system
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: foo-80
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-ingress-bar-80
+  namespace: foo2
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: NetworkAuthentication
+      name: acorn-ingress-network-authentication
+      namespace: kube-system
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: bar-80
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-ingress-router
+  namespace: acorn-system
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: NetworkAuthentication
+      name: acorn-ingress-network-authentication
+      namespace: kube-system
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: router
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: AuthorizationPolicy
+metadata:
+  name: authz-profile-acorn-router
+  namespace: acorn-system
+spec:
+  requiredAuthenticationRefs:
+    - group: policy.linkerd.io
+      kind: MeshTLSAuthentication
+      name: mesh-authn-profile-acorn
+      namespace: acorn
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: router
+---

--- a/pkg/controller/testdata/authorization-policy-with-router-service/input.yaml
+++ b/pkg/controller/testdata/authorization-policy-with-router-service/input.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    foo: bar
+  labels:
+    acorn.io/project: "true"
+  name: acorn
+spec:
+  finalizers:
+    - kubernetes
+status:
+  phase: Active

--- a/pkg/controller/testdata/server/expected.yaml
+++ b/pkg/controller/testdata/server/expected.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: test
   labels:
     acorn.io/service-name: foo
+    acorn.io/app-name: foo
+    acorn.io/app-namespace: foo
 spec:
   podSelector:
     matchLabels:

--- a/pkg/controller/testdata/server/input.yaml
+++ b/pkg/controller/testdata/server/input.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: foo
   namespace: test
+  labels:
+    acorn.io/app-name: "foo"
+    acorn.io/app-namespace: "foo"
 spec:
   ports:
     - appProtocol: HTTP


### PR DESCRIPTION
Signed-off-by: Daishan Peng <daishan@acorn.io>

We need to add authrization policy for servers that were defined in acorn-system, as these services are created by routers and will need to be routable with projects.