### PR TITLE
Add a default deny annotation to project namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Acorn linkerd plugin provides a way for acorn to integrate with linkerd service 
 
 3. Automatically configure linkerd policies to ensure project level networking isolation between acorn projects.
 
+When installing Acorn in your local cluster, if you want to be able to use this plugin, be sure to include these command line options:
+
+```bash
+acorn install --propagate-project-annotation "linkerd.io/inject","config.linkerd.io/default-inbound-policy" --set-pod-security-enforce-profile=false
+```
+
+> Note: if you are using the Cilium CNI, you do not need the `--set-pod-security-enforce-profile=false` option.
+
 ### Build
 
 ```bash
@@ -19,7 +27,7 @@ make build
 The best way to run the plugin is through acorn. Run 
 
 ```bash
-acorn run --name controller -i .
+acorn run --name acorn-linkerd-plugin -i .
 ```
 
 ### Production

--- a/pkg/controller/handlers.go
+++ b/pkg/controller/handlers.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	serviceMeshAnnotation     = "linkerd.io/inject"
+	defaultPolicyAnnotation   = "config.linkerd.io/default-inbound-policy"
 	proxySidecarContainerName = "linkerd-proxy"
 
 	ingressNetworkAuthenticationName = "acorn-ingress-network-authentication"
@@ -52,8 +53,9 @@ func AddAnnotations(req router.Request, resp router.Response) error {
 		return nil
 	}
 
-	logrus.Infof("Updating project %v to inject linkerd service mesh annotation", projectNamespace.Name)
+	logrus.Infof("Updating project %v to inject linkerd service mesh annotations", projectNamespace.Name)
 	projectNamespace.Annotations[serviceMeshAnnotation] = "enabled"
+	projectNamespace.Annotations[defaultPolicyAnnotation] = "deny"
 	if err := req.Client.Update(req.Ctx, projectNamespace); err != nil {
 		return err
 	}


### PR DESCRIPTION
This change adds an additional linkerd annotation to each project namespace (which will be propagated to app namespaces as long as the acorn controller is configured to do so). This annotation tells all the linkerd sidecar containers to default deny all incoming traffic unless there is an AuthorizationPolicy that specifically allows it to come in.

The implication of this is that, in order for a port running on a container to be accessible, it **must** be explicitly stated in the Acornfile. Otherwise, even though the container might be listening on that port, linkerd is just going to block all traffic coming in.

I tested both HTTP and SSH connections with these changes. Cross-project HTTP and SSH were both successfully blocked, while intra-project HTTP and SSH were both allowed (again, as long as I specified the correct port in the Acornfile for my apps).

It should be noted that this does **NOT** block ICMP ping traffic. Based on my research, I don't think it is actually possible to block this by using linkerd, because I think linkerd only cares about TCP and UDP. Something lower-level like k8s NetworkPolicies might be our only option for that, but that's a whole different discussion.